### PR TITLE
Fix homepage video autoplay issues

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -286,20 +286,19 @@ if (count($json_array_billboard) < 6) {
                 console.log('desktop');
                 $( '.homepage-portal-link.desktop' ).click();
             } else {
-                var dWidth = $( document ).width();
-                if( dWidth > 768 ) {
-                    console.log('desktop');
-                    console.log( dWidth );
-                    $( '.homepage-video-link.desktop' ).click();
-                } else {
-                    console.log('mobile');
-                    console.log( dWidth );
-                    $( '.homepage-video-link.mobile' ).click();
-                }
+				
             }
         } else if (window.location.search === "?auto") {
-
-            $( '.homepage-video-link' ).click();
+            var dWidth = $( document ).width();
+            if( dWidth > 768 ) {
+                console.log('desktop');
+                console.log( dWidth );
+                $( '.homepage-video-link.desktop' ).click();
+            } else {
+                console.log('mobile');
+                console.log( dWidth );
+                $( '.homepage-video-link.mobile' ).click();
+            }
         }
 
         /* initialize homepage slideshow */


### PR DESCRIPTION
Current site is loading an incorrectly sized video player when the homepage video autoplay link (www.kobaltmusic.com?auto) is visited. Also, the portal video autoplay link (www.kobaltmusic.com?portal) is not working.

This fix corrects these two bugs, correctly loading the videos for both autoplay links.

The fix can be seen in a test environment here:
http://www.case-agency.com/dev/kobalt/gh_082715?auto
http://www.case-agency.com/dev/kobalt/gh_082715?portal